### PR TITLE
Overlay working on omarchy with protontricks + transparency fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,34 @@ flatpak run \
 
 NOTE: After performing login for the first time, you may need to restart the game for the Untapped.gg Companion to work correctly.
 
+Alternative: Native protontricks (non-flatpak)
+==============================================
+
+If you have `protontricks` from your distro's package manager (e.g.
+`pacman -S protontricks` on Arch, `dnf install protontricks` on
+Fedora) instead of the flatpak, the install steps above need two
+adjustments:
+
+* Replace `flatpak run --env=PROTON_VERSION='Proton Experimental' com.github.Matoking.protontricks` with just `protontricks`.
+* Pass `--no-bwrap` for the verb install. Native protontricks sandboxes its wine call with bubblewrap by default, which prevents wine from reading Steam's compatdata prefix.
+
+So step 3 (verb install) becomes:
+
+```bash
+cd wine_untappedgg_companion
+protontricks "${STEAM_APPID}" --no-bwrap -q untappedgg_companion.verb
+```
+
+And step 5 (assemble the launch option) takes a `PROTONTRICKS_NATIVE=1` env var:
+
+```bash
+PROTONTRICKS_NATIVE=1 ./assemble_proton_cmd.sh "${STEAM_APPID}"
+```
+
+The path it prints will be under `~/.local/share/Steam/...` (not the
+flatpak's `~/.var/app/com.valvesoftware.Steam/...`), since native
+protontricks talks to the regular Steam install.
+
 Additional Information:
 =======================
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,13 @@ protontricks talks to the regular Steam install.
 Additional Information:
 =======================
 
-NOTE: At this time, the overlay UI causes significant weirdness. We disable the overlay, and instead use pop-out windows were possible to workaround the issue.
+NOTE: On Wine/XWayland the Untapped.gg Companion overlay can render solid-black because Electron's GPU-accelerated compositor doesn't produce alpha-correct output that Wine can hand to the X server with alpha intact. Appending `--disable-gpu --disable-gpu-compositing` to the launch command falls back to Chromium's CPU compositor, which fixes overlay transparency. Confirmed working on Hyprland (Arch / Omarchy) with Proton Experimental:
+
+```
+PROTON_REMOTE_DEBUG_CMD="<...>/Untapped.gg\ Companion.exe --disable-gpu --disable-gpu-compositing" %command%
+```
+
+If the overlay still doesn't work for you (or you'd rather not pay the CPU-compositor cost), you can disable the overlay in the companion settings and use pop-out (Player Deck / Opponent Deck) windows instead — those are regular floating windows and don't need the flags.
 
 For more information, see here:
 

--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ PROTON_REMOTE_DEBUG_CMD="<...>/Untapped.gg\ Companion.exe --disable-gpu --disabl
 
 If the overlay still doesn't work for you (or you'd rather not pay the CPU-compositor cost), you can disable the overlay in the companion settings and use pop-out (Player Deck / Opponent Deck) windows instead — those are regular floating windows and don't need the flags.
 
+Hyprland users: see [`examples/hyprland-windows.conf`](./examples/hyprland-windows.conf) for starter window rules.
+
 For more information, see here:
 
 * [Known Overlay Issues](https://github.com/sabedevops/wine_untappedgg_companion/wiki/Known-Overlay-Issues)

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ So step 3 (verb install) becomes:
 
 ```bash
 cd wine_untappedgg_companion
-protontricks "${STEAM_APPID}" --no-bwrap -q untappedgg_companion.verb
+protontricks --no-bwrap "${STEAM_APPID}" -q untappedgg_companion.verb
 ```
 
 And step 5 (assemble the launch option) takes a `PROTONTRICKS_NATIVE=1` env var:

--- a/assemble_proton_cmd.sh
+++ b/assemble_proton_cmd.sh
@@ -7,10 +7,23 @@ fi
 
 STEAM_APPID="${1}"
 
+# Set PROTONTRICKS_NATIVE=1 if protontricks is installed via your distro
+# package manager rather than the flatpak (e.g. `pacman -S protontricks`
+# on Arch, `dnf install protontricks` on Fedora). Native protontricks
+# sandboxes its wine call with bubblewrap by default, which prevents it
+# from reading Steam's compatdata prefix, so --no-bwrap is required.
+protontricks_wrap() {
+    if [ "${PROTONTRICKS_NATIVE:-0}" = "1" ]; then
+        protontricks --no-bwrap "$@"
+    else
+        flatpak run \
+            --env=PROTON_VERSION="Proton Experimental" \
+            com.github.Matoking.protontricks "$@"
+    fi
+}
+
 getWineEnv() {
-    flatpak run \
-        --env=PROTON_VERSION="Proton Experimental" \
-        com.github.Matoking.protontricks -c "wine cmd.exe /c echo %${1}%" "$STEAM_APPID" 2> /dev/null | dos2unix
+    protontricks_wrap -c "wine cmd.exe /c echo %${1}%" "$STEAM_APPID" 2> /dev/null | dos2unix
 }
 
 

--- a/examples/hyprland-windows.conf
+++ b/examples/hyprland-windows.conf
@@ -1,0 +1,22 @@
+# Untapped.gg Companion — Hyprland window rules.
+# Match by title; the companion shares its WM class with the host game.
+
+# --- Overlay (requires --disable-gpu --disable-gpu-compositing — see README) ---
+windowrule = tag -default-opacity, match:title ^Untapped\.gg Overlay$
+windowrule = opacity 1.0 override 1.0 override, match:title ^Untapped\.gg Overlay$
+windowrule = float on, match:title ^Untapped\.gg Overlay$
+windowrule = suppress_event fullscreen maximize, match:title ^Untapped\.gg Overlay$
+windowrule = no_initial_focus on, match:title ^Untapped\.gg Overlay$
+windowrule = no_focus on, match:title ^Untapped\.gg Overlay$
+windowrule = no_blur on, match:title ^Untapped\.gg Overlay$
+windowrule = border_size 0, match:title ^Untapped\.gg Overlay$
+windowrule = move 0 0, match:title ^Untapped\.gg Overlay$
+windowrule = size 100% 100%, match:title ^Untapped\.gg Overlay$
+
+# --- Main companion window ---
+windowrule = float on, match:title ^Untapped\.gg$
+windowrule = suppress_event fullscreen, match:title ^Untapped\.gg$
+
+# --- Deck windows (Player Deck / Opponent Deck) ---
+windowrule = float on, match:title .*Deck - Untapped\.gg$
+windowrule = suppress_event fullscreen, match:title .*Deck - Untapped\.gg$


### PR DESCRIPTION
I set things up with protontricks instead of flatpak but I think the overlay 'fix' to fallback to CPU compositor so we have the alpha channel behaving should work fine on flatpak installs. 

There are window rules from the hyprland setup/config used with MTGA. Here is a screenshot with overlay working nicely in game.
<img width="1920" height="1080" alt="screenshot-2026-06-14_21-17-19" src="https://github.com/user-attachments/assets/e5258536-2ba9-4e09-8516-51e1b8ba88a3" />

Let me know if you'd like more info / hope this helps